### PR TITLE
Attempt to use delegating Spliterators on Android 7.0 (Nougat)+.

### DIFF
--- a/src/main/java/java8/util/HMSpliterators.java
+++ b/src/main/java/java8/util/HMSpliterators.java
@@ -370,7 +370,7 @@ final class HMSpliterators {
 
         static Class<?> nodeClass() throws ClassNotFoundException {
             String nodeName = new StringBuilder("java.util.HashMap$")
-                    .append((Spliterators.IS_ANDROID || Spliterators.JRE_HAS_STREAMS) ? "Node"
+                    .append((Spliterators.IS_ANDROID || Spliterators.HAS_STREAMS) ? "Node"
                             : "Entry").toString();
             try {
                 return Class.forName(nodeName);

--- a/src/main/java/java8/util/Spliterators.java
+++ b/src/main/java/java8/util/Spliterators.java
@@ -53,7 +53,6 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.PriorityBlockingQueue;
 
-import java8.util.Objects;
 import java8.util.function.Consumer;
 import java8.util.function.DoubleConsumer;
 import java8.util.function.IntConsumer;
@@ -71,25 +70,27 @@ import java8.util.function.LongConsumer;
 public final class Spliterators {
 
     private static final String NATIVE_OPT_ENABLED_P = Spliterators.class.getName() + ".assume.oracle.collections.impl";
-    private static final String JRE_DELEGATION_ENABLED_P = Spliterators.class.getName() + ".jre.delegation.enabled";
+    private static final String DELEGATION_ENABLED_P = Spliterators.class.getName() + ".jre.delegation.enabled";
     private static final String RNDACC_SPLITER_ENABLED_P = Spliterators.class.getName() + ".randomaccess.spliterator.enabled";
 
     // defaults to true
     static final boolean NATIVE_SPECIALIZATION = getBooleanPropVal(NATIVE_OPT_ENABLED_P, true);
     // defaults to true
-    static final boolean JRE_DELEGATION_ENABLED = getBooleanPropVal(JRE_DELEGATION_ENABLED_P, true);
+    static final boolean DELEGATION_ENABLED = getBooleanPropVal(DELEGATION_ENABLED_P, true);
+
     // introduced in 1.4.3 - just in case something gets wrong (defaults to true)
     private static final boolean ALLOW_RNDACC_SPLITER_OPT = getBooleanPropVal(RNDACC_SPLITER_ENABLED_P, true);
     // is this RoboVM? (defaults to false)
-    private static final boolean IS_ROBOVM = isClassPresent("org.robovm.rt.bro.Bro");
+    private static final boolean IS_ROBOVM = isRoboVm();
+
     // is this Android? (defaults to false)
-    static final boolean IS_ANDROID = isClassPresent("android.util.DisplayMetrics") || IS_ROBOVM;
+    static final boolean IS_ANDROID = isAndroid();
     // is this an Apache Harmony-based Android? (defaults to false)
     static final boolean IS_HARMONY_ANDROID = IS_ANDROID && !isClassPresent("android.opengl.GLES32$DebugProc");
     // is this Java 6? (defaults to false - as of 1.4.2, Android doesn't get identified as Java 6 anymore!)
     static final boolean IS_JAVA6 = !IS_ANDROID && isJava6();
     // defaults to false
-    static final boolean JRE_HAS_STREAMS = isStreamEnabledJRE();
+    static final boolean HAS_STREAMS = isStreamEnabled();
 
     // Suppresses default constructor, ensuring non-instantiability.
     private Spliterators() {}
@@ -909,8 +910,8 @@ public final class Spliterators {
     public static <T> Spliterator<T> spliterator(Collection<? extends T> c) {
         Objects.requireNonNull(c);
 
-        if (JRE_HAS_STREAMS && JRE_DELEGATION_ENABLED) {
-            return jreDelegatingSpliterator(c);
+        if (HAS_STREAMS && DELEGATION_ENABLED) {
+            return delegatingSpliterator(c);
         }
 
         String name = c.getClass().getName();
@@ -1041,7 +1042,7 @@ public final class Spliterators {
         return spliterator(c, 0);
     }
 
-    private static <T> Spliterator<T> jreDelegatingSpliterator(Collection<? extends T> c) {
+    private static <T> Spliterator<T> delegatingSpliterator(Collection<? extends T> c) {
         return new DelegatingSpliterator<T>(((Collection<T>) c).spliterator());
     }
 
@@ -3276,13 +3277,21 @@ public final class Spliterators {
         return isVersionBelow("java.class.version", 51.0);
     }
 
+    private static boolean isRoboVm() {
+        return isClassPresent("org.robovm.rt.bro.Bro");
+    }
+
+    private static boolean isAndroid() {
+        return isClassPresent("android.util.DisplayMetrics") || IS_ROBOVM;
+    }
+
     /**
-     * Does the current JRE have the JSR 335 libraries?
+     * Does the current platform have the JSR 335 APIs?
      * @return {@code true} if yes, otherwise {@code false}.
      */
-    private static boolean isStreamEnabledJRE() {
+    private static boolean isStreamEnabled() {
         // a) must have at least major version number 52 (Java 8)
-        if (isVersionBelow("java.class.version", 52.0)) {
+        if (!isAndroid() && isVersionBelow("java.class.version", 52.0)) {
             return false;
         }
         // b) j.u.f.Consumer & j.u.Spliterator must exist


### PR DESCRIPTION
Prior to this change, delegating Spliterators were only used on
limited platforms (not including Android). This can be demonstrated
with the following test which now passes but would previously have
failed (expected:<[Delegating]Spliterator> but was:<[Entry]Spliterator>):

```
@Test
public void testAndroidN_delegatingSpliterator() {
  Spliterator spliterator = Spliterators.spliterator(
      new HashMap<>().entrySet());
  assertEquals("DelegatingSpliterator",
      spliterator.getClass().getSimpleName());
}
```

I did not perform any other verification steps so this change may
contain errors. Specifically, I couldn't figure out how to run
streamsupport's test suite so I didn't run them: the gradle rule
("test") failed to compile because it couldn't find the Maps2 class
(probably a missing dependency config somewhere?) and "mvn test"
claimed that there were zero tests to run.

To clarify that additional platforms now offer delegating
Spliterators, renamed JRE_DELEGATION_ENABLED and friends to
DELEGATION_ENABLED. The corresponding system property's name remains
".jre.delegation.enabled" for the following reasons:

   (a) to maintain backwards compatibility,
   (b) because system properties make less sense on Android (there is
       no command line to set them from, so they'd need to be set from
       code before Spliterators.<clinit> runs)

To make the code more robust, refactored logic for static initialization
logic in Spliterators.java into static helper methods. The advantage is
that those methods can be called in arbitrary order, including during
initialization of other static fields. If methods such as
isStreamEnabled() were reading those static fields directly while
computing the value for another static field, the correct initialization
order would depend on the order those static fields appear in the .java
file, which would be fragile and could easily break.
